### PR TITLE
Parent index sorted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ group :development, :test do
   gem "capybara"
   gem "launchy"
   gem "simplecov" #save_and_open_page
-  gem "shoulda-matchers" #test associations/relationships 
+  gem "shoulda-matchers" #test associations/relationships
   gem "orderly"
   gem "factory_bot_rails"
   gem "faker"

--- a/app/controllers/gyms_controller.rb
+++ b/app/controllers/gyms_controller.rb
@@ -1,6 +1,6 @@
 class GymsController < ApplicationController
   def index
-    @gyms = Gym.order_by_created
+    @gyms = Gym.ordered_members
   end
 
   def show

--- a/app/controllers/gyms_controller.rb
+++ b/app/controllers/gyms_controller.rb
@@ -1,6 +1,6 @@
 class GymsController < ApplicationController
   def index
-    @gyms = Gym.all.order(:created_at)
+    @gyms = Gym.order_by_created
   end
 
   def show

--- a/app/models/gym.rb
+++ b/app/models/gym.rb
@@ -1,3 +1,14 @@
 class Gym < ApplicationRecord
   has_many :members
+
+  def self.order_by_created
+    #self.order(created_at: :desc)
+    # ^ does the same thing but as a reminder that this is a class method
+    order(created_at: :desc)
+  end
+
+  def number_of_members
+    members.count
+  end
+
 end

--- a/app/models/gym.rb
+++ b/app/models/gym.rb
@@ -1,7 +1,7 @@
 class Gym < ApplicationRecord
   has_many :members
 
-  def self.order_by_created
+  def self.ordered_members
     #self.order(created_at: :desc)
     # ^ does the same thing but as a reminder that this is a class method
     order(created_at: :desc)

--- a/app/views/gyms/index.html.erb
+++ b/app/views/gyms/index.html.erb
@@ -1,4 +1,5 @@
 <h1>Every Gym Everywhere All at Once</h1>
+<a href="/gyms/">Every Gym Everywhere</a>
 <a href="/members/">Every Member Everywhere</a>
 <% @gyms.each do |gym| %>
   <h3>Gym Name: <%= gym.name %></h2>

--- a/app/views/gyms/index.html.erb
+++ b/app/views/gyms/index.html.erb
@@ -1,7 +1,5 @@
 <h1>Every Gym Everywhere All at Once</h1>
 <% @gyms.each do |gym| %>
-  <h2>Gym Name: <%= gym.name %></h2>
-  <h3>Member Cost Per Month: $<%= gym.member_cost %></h3>
-  <h3>Day Rate for Guests: $<%= gym.guest_cost %></h3>
-  <p>In Colorado: <%= gym.in_colorado %></p>
+  <h3>Gym Name: <%= gym.name %></h2>
+  <p>Created At: <%= gym.created_at %></p>
 <% end %>

--- a/app/views/gyms/index.html.erb
+++ b/app/views/gyms/index.html.erb
@@ -1,4 +1,5 @@
 <h1>Every Gym Everywhere All at Once</h1>
+<a href="/members/">Every Member Everywhere</a>
 <% @gyms.each do |gym| %>
   <h3>Gym Name: <%= gym.name %></h2>
   <p>Created At: <%= gym.created_at %></p>

--- a/app/views/gyms/members/index.html.erb
+++ b/app/views/gyms/members/index.html.erb
@@ -1,4 +1,5 @@
 <h1><%= @gym.name %></h1>
+<a href="/gyms/">Every Gym Everywhere</a>
 <a href="/members/">Every Member Everywhere</a>
 <h2>Members</h2>
 <% @members.each do |member| %>

--- a/app/views/gyms/members/index.html.erb
+++ b/app/views/gyms/members/index.html.erb
@@ -1,4 +1,5 @@
 <h1><%= @gym.name %></h1>
+<a href="/members/">Every Member Everywhere</a>
 <h2>Members</h2>
 <% @members.each do |member| %>
   <h3>Member Name: <%= member.name %></h3>

--- a/app/views/gyms/show.html.erb
+++ b/app/views/gyms/show.html.erb
@@ -2,6 +2,7 @@
 <a href="/members/">Every Member Everywhere</a>
 <h1>Gym Name: <%= @gym.name %></h1>
 <h2>Number of Members: <%= @gym.number_of_members %></h2>
+<a href="/gyms/<%= @gym.id %>/members">Gym Members</a>
 <h3>Member Cost Per Month: $<%= @gym.member_cost %></h3>
 <h3>Day Rate for Guests: $<%= @gym.guest_cost %></h3>
 <p>In Colorado: <%= @gym.in_colorado %></p>

--- a/app/views/gyms/show.html.erb
+++ b/app/views/gyms/show.html.erb
@@ -1,3 +1,4 @@
+<a href="/members/">Every Member Everywhere</a>
 <h1>Gym Name: <%= @gym.name %></h1>
 <h2>Number of Members: <%= @gym.number_of_members %></h2>
 <h3>Member Cost Per Month: $<%= @gym.member_cost %></h3>

--- a/app/views/gyms/show.html.erb
+++ b/app/views/gyms/show.html.erb
@@ -1,4 +1,5 @@
-<h1>Gym Name: <%= @gym.name %></h2>
-<h2>Member Cost Per Month: $<%= @gym.member_cost %></h2>
-<h2>Day Rate for Guests: $<%= @gym.guest_cost %></h2>
+<h1>Gym Name: <%= @gym.name %></h1>
+<h2>Number of Members: <%= @gym.number_of_members %></h2>
+<h3>Member Cost Per Month: $<%= @gym.member_cost %></h3>
+<h3>Day Rate for Guests: $<%= @gym.guest_cost %></h3>
 <p>In Colorado: <%= @gym.in_colorado %></p>

--- a/app/views/gyms/show.html.erb
+++ b/app/views/gyms/show.html.erb
@@ -1,3 +1,4 @@
+<a href="/gyms/">Every Gym Everywhere</a>
 <a href="/members/">Every Member Everywhere</a>
 <h1>Gym Name: <%= @gym.name %></h1>
 <h2>Number of Members: <%= @gym.number_of_members %></h2>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -1,4 +1,5 @@
 <h1>Every Member Everywhere All at Once</h1>
+<a href="/gyms/">Every Gym Everywhere</a>
 <a href="/members/">Every Member Everywhere</a>
 <% @members.each do |member| %>
   <h2>Member Name: <%= member.name %></h2>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -1,4 +1,5 @@
 <h1>Every Member Everywhere All at Once</h1>
+<a href="/members/">Every Member Everywhere</a>
 <% @members.each do |member| %>
   <h2>Member Name: <%= member.name %></h2>
   <p>Money Spent: $<%= member.money_spent %></p>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -1,3 +1,4 @@
+<a href="/members/">Every Member Everywhere</a>
 <h1>Member Name: <%= @member.name %></h1>
 <p>Money Spent: $<%= @member.money_spent %></p>
 <p>Resident of CO?: <%= @member.co_resident %></p>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -1,3 +1,4 @@
+<a href="/gyms/">Every Gym Everywhere</a>
 <a href="/members/">Every Member Everywhere</a>
 <h1>Member Name: <%= @member.name %></h1>
 <p>Money Spent: $<%= @member.money_spent %></p>

--- a/spec/features/gyms/index_spec.rb
+++ b/spec/features/gyms/index_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "gyms index page", type: :feature do
       member_cost: 75,
       guest_cost: 20,
       in_colorado: true)
+      
     visit "/gyms"
     # save_and_open_page
 
@@ -34,14 +35,15 @@ RSpec.describe "gyms index page", type: :feature do
   # And next to each of the records I see when it was created
   it "can show all of the gyms in the order they were created at" do
     gym1 = Gym.create!(name: "Movement",
-                        member_cost:  92,
-                        guest_cost:   25,
-                        in_colorado:  true,
-                        created_at: Date.today - 1)
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true,
+      created_at: Date.today - 1)
     gym2 = Gym.create!(name: "Touchstone",
-                        member_cost:  100,
-                        guest_cost:   30,
-                        in_colorado:  false)
+      member_cost: 100,
+      guest_cost: 30,
+      in_colorado: false)
+
     visit "/gyms"
     # save_and_open_page
 
@@ -54,20 +56,44 @@ RSpec.describe "gyms index page", type: :feature do
   # As a visitor
   # When I visit any page on the site
   # Then I see a link at the top of the page that takes me to the Child Index
-  it "can show a link to the members page" do
+  it "can show a link to the members index page" do
     gym1 = Gym.create!(name: "Movement",
-                        member_cost:  92,
-                        guest_cost:   25,
-                        in_colorado:  true,
-                        created_at: Date.today - 1)
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true,
+      created_at: Date.today - 1)
     gym2 = Gym.create!(name: "Touchstone",
-                        member_cost:  100,
-                        guest_cost:   30,
-                        in_colorado:  false)
+      member_cost: 100,
+      guest_cost: 30,
+      in_colorado: false)
+
     visit "/gyms"
     # save_and_open_page
 
     expect(page).to have_content("Every Member Everywhere")
     expect(page).to have_link("Every Member Everywhere", href: "/members/")
+  end
+
+  # User Story 9, Parent Index Link
+
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Parent Index
+  it "can show a link to the gyms index page" do
+    gym1 = Gym.create!(name: "Movement",
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true,
+      created_at: Date.today - 1)
+    gym2 = Gym.create!(name: "Touchstone",
+      member_cost: 100,
+      guest_cost: 30,
+      in_colorado: false)
+
+    visit "/gyms"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Gym Everywhere")
+    expect(page).to have_link("Every Gym Everywhere", href: "/gyms/")
   end
 end

--- a/spec/features/gyms/index_spec.rb
+++ b/spec/features/gyms/index_spec.rb
@@ -48,4 +48,26 @@ RSpec.describe "gyms index page", type: :feature do
     expect("Gym Name: #{gym2.name}").to appear_before("Gym Name: #{gym1.name}")
     expect("Created At: #{gym2.created_at}").to appear_before("Created At: #{gym1.created_at}")
   end
+
+  # User Story 8, Child Index Link
+
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Child Index
+  it "can show a link to the members page" do
+    gym1 = Gym.create!(name: "Movement",
+                        member_cost:  92,
+                        guest_cost:   25,
+                        in_colorado:  true,
+                        created_at: Date.today - 1)
+    gym2 = Gym.create!(name: "Touchstone",
+                        member_cost:  100,
+                        guest_cost:   30,
+                        in_colorado:  false)
+    visit "/gyms"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Member Everywhere")
+    expect(page).to have_link("Every Member Everywhere", href: "/members/")
+  end
 end

--- a/spec/features/gyms/index_spec.rb
+++ b/spec/features/gyms/index_spec.rb
@@ -9,25 +9,21 @@ RSpec.describe "gyms index page", type: :feature do
   # Then I see the name of each gym record in the system
   it "can show all of the gyms" do
     gym1 = Gym.create!(name: "Movement",
-                      member_cost:  92,
-                      guest_cost:   25,
-                      in_colorado:  true)
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
     gym2 = Gym.create!(name: "The Spot",
-                      member_cost:  75,
-                      guest_cost:   20,
-                      in_colorado:  true)
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
     visit "/gyms"
     # save_and_open_page
 
     expect(page).to have_content("Gym Name: #{gym1.name}")
-    expect(page).to have_content("Member Cost Per Month: $#{gym1.member_cost}")
-    expect(page).to have_content("Day Rate for Guests: $#{gym1.guest_cost}")
-    expect(page).to have_content("In Colorado: #{gym1.in_colorado}")
+    expect(page).to have_content("Created At: #{gym1.created_at}")
 
     expect(page).to have_content("Gym Name: #{gym2.name}")
-    expect(page).to have_content("Member Cost Per Month: $#{gym2.member_cost}")
-    expect(page).to have_content("Day Rate for Guests: $#{gym2.guest_cost}")
-    expect(page).to have_content("In Colorado: #{gym2.in_colorado}")
+    expect(page).to have_content("Created At: #{gym2.created_at}")
   end
 
   # User Story 6, Parent Index sorted by Most Recently Created
@@ -36,21 +32,20 @@ RSpec.describe "gyms index page", type: :feature do
   # When I visit the parent index,
   # I see that records are ordered by most recently created first
   # And next to each of the records I see when it was created
-  it "can show all of the gyms" do
+  it "can show all of the gyms in the order they were created at" do
+    gym1 = Gym.create!(name: "Movement",
+                        member_cost:  92,
+                        guest_cost:   25,
+                        in_colorado:  true,
+                        created_at: Date.today - 1)
     gym2 = Gym.create!(name: "Touchstone",
                         member_cost:  100,
                         guest_cost:   30,
                         in_colorado:  false)
-    gym1 = Gym.create!(name: "Movement",
-                        member_cost:  92,
-                        guest_cost:   25,
-                        in_colorado:  true)
     visit "/gyms"
-    save_and_open_page
+    # save_and_open_page
 
     expect("Gym Name: #{gym2.name}").to appear_before("Gym Name: #{gym1.name}")
-    expect("Member Cost Per Month: $#{gym2.member_cost}").to appear_before("Member Cost Per Month: $#{gym1.member_cost}")
-    expect("Day Rate for Guests: $#{gym2.guest_cost}").to appear_before("Day Rate for Guests: $#{gym1.guest_cost}")
-    expect("In Colorado: #{gym2.in_colorado}").to appear_before("In Colorado: #{gym1.in_colorado}")
+    expect("Created At: #{gym2.created_at}").to appear_before("Created At: #{gym1.created_at}")
   end
 end

--- a/spec/features/gyms/members/index_spec.rb
+++ b/spec/features/gyms/members/index_spec.rb
@@ -70,11 +70,36 @@ end
   # As a visitor
   # When I visit any page on the site
   # Then I see a link at the top of the page that takes me to the Child Index
-  it "can show a link to the members page" do
+  it "can show a link to the members index page" do
+    visit "/gyms/#{@gym1.id}/members"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Member Everywhere")
+    expect(page).to have_link("Every Member Everywhere", href: "/members/")
+
     visit "/gyms/#{@gym2.id}/members"
     # save_and_open_page
 
     expect(page).to have_content("Every Member Everywhere")
     expect(page).to have_link("Every Member Everywhere", href: "/members/")
+  end
+
+  # User Story 9, Parent Index Link
+
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Parent Index
+  it "can show a link to the gyms index page" do
+    visit "/gyms/#{@gym1.id}/members"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Gym Everywhere")
+    expect(page).to have_link("Every Gym Everywhere", href: "/gyms/")
+
+    visit "/gyms/#{@gym2.id}/members"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Gym Everywhere")
+    expect(page).to have_link("Every Gym Everywhere", href: "/gyms/")
   end
 end

--- a/spec/features/gyms/members/index_spec.rb
+++ b/spec/features/gyms/members/index_spec.rb
@@ -64,4 +64,17 @@ end
     expect(page).to have_content("Resident of CO?: #{@member4.co_resident}")
     expect(page).to have_content("Member of: #{@gym2.id}")
   end
+
+  # User Story 8, Child Index Link
+
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Child Index
+  it "can show a link to the members page" do
+    visit "/gyms/#{@gym2.id}/members"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Member Everywhere")
+    expect(page).to have_link("Every Member Everywhere", href: "/members/")
+  end
 end

--- a/spec/features/gyms/members/index_spec.rb
+++ b/spec/features/gyms/members/index_spec.rb
@@ -9,31 +9,31 @@ RSpec.describe "parent child index page", type: :feature do
   # (data from each column that is on the child table)
   before :each do
     @gym1 = Gym.create!(name: "Movement",
-                        member_cost:  92,
-                        guest_cost:   25,
-                        in_colorado:  true)
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
     @member1 = Member.create!(name: "Garrett",
-                              money_spent: 300,
-                              co_resident: true,
-                              gym_id: @gym1.id)
+      money_spent: 300,
+      co_resident: true,
+      gym_id: @gym1.id)
     @member2 = Member.create!(name: "Audrey",
-                              money_spent: 300,
-                              co_resident: true,
-                              gym_id: @gym1.id)
+      money_spent: 300,
+      co_resident: true,
+      gym_id: @gym1.id)
 
     @gym2 = Gym.create!(name: "The Spot",
-                        member_cost:  75,
-                        guest_cost:   20,
-                        in_colorado:  true)
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
     @member3 = Member.create!(name: "Brad",
-                              money_spent: 250,
-                              co_resident: false,
-                              gym_id: @gym2.id)
+      money_spent: 250,
+      co_resident: false,
+      gym_id: @gym2.id)
     @member4 = Member.create!(name: "Sarah",
-                              money_spent: 250,
-                              co_resident: false,
-                              gym_id: @gym2.id)
-  end
+      money_spent: 250,
+      co_resident: false,
+      gym_id: @gym2.id)
+end
 
   it "can show one of the members" do
     visit "/gyms/#{@gym1.id}/members"

--- a/spec/features/gyms/show_spec.rb
+++ b/spec/features/gyms/show_spec.rb
@@ -97,5 +97,47 @@ RSpec.describe "gyms index page", type: :feature do
     expect(page).to have_content("Day Rate for Guests: $#{gym2.guest_cost}")
     expect(page).to have_content("In Colorado: #{gym2.in_colorado}")
   end
+
+  # User Story 8, Child Index Link
+
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Child Index
+  it "can show a link to the members page" do
+    gym1 = Gym.create!(name: "Movement",
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
+    member1 = Member.create!(name: "Garrett",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+    member2 = Member.create!(name: "Audrey",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+
+    gym2 = Gym.create!(name: "The Spot",
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
+    member3 = Member.create!(name: "Brad",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+    member4 = Member.create!(name: "Sarah",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+    member5 = Member.create!(name: "Chris",
+      money_spent: 250,
+      co_resident: true,
+      gym_id: gym2.id)
+
+    visit "/gyms/#{gym1.id}"
+
+    expect(page).to have_content("Every Member Everywhere")
+    expect(page).to have_link("Every Member Everywhere", href: "/members/")
+  end
 end
 

--- a/spec/features/gyms/show_spec.rb
+++ b/spec/features/gyms/show_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe "gyms index page", type: :feature do
   # Then I see the gym with that id including the gym's attributes
   # (data from each column that is on the gym table)
   it "can show the first gym of the gyms" do
-    gym1 = Gym.create!(name:         "Movement",
-                      member_cost:  92,
-                      guest_cost:   25,
-                      in_colorado:  true)
-    gym2 = Gym.create!(name:         "The Spot",
-                      member_cost:  75,
-                      guest_cost:   20,
-                      in_colorado:  true)
+    gym1 = Gym.create!(name: "Movement",
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
+    gym2 = Gym.create!(name: "The Spot",
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
     visit "/gyms/#{gym1.id}"
     # save_and_open_page
 
@@ -26,18 +26,73 @@ RSpec.describe "gyms index page", type: :feature do
   end
 
   it "can show the other gym of the gyms" do
-    gym1 = Gym.create!(name:         "Movement",
-                      member_cost:  92,
-                      guest_cost:   25,
-                      in_colorado:  true)
-    gym2 = Gym.create!(name:         "The Spot",
-                      member_cost:  75,
-                      guest_cost:   20,
-                      in_colorado:  true)
+    gym1 = Gym.create!(name: "Movement",
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
+    gym2 = Gym.create!(name: "The Spot",
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
     visit "/gyms/#{gym2.id}"
     # save_and_open_page
 
     expect(page).to have_content("Gym Name: #{gym2.name}")
+    expect(page).to have_content("Member Cost Per Month: $#{gym2.member_cost}")
+    expect(page).to have_content("Day Rate for Guests: $#{gym2.guest_cost}")
+    expect(page).to have_content("In Colorado: #{gym2.in_colorado}")
+  end
+
+  # User Story 7, Parent Child Count
+
+  # As a visitor
+  # When I visit a parent's show page
+  # I see a count of the number of children associated with this parent
+  it "can show the other gym of the gyms" do
+    gym1 = Gym.create!(name: "Movement",
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
+    member1 = Member.create!(name: "Garrett",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+    member2 = Member.create!(name: "Audrey",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+
+    gym2 = Gym.create!(name: "The Spot",
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
+    member3 = Member.create!(name: "Brad",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+    member4 = Member.create!(name: "Sarah",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+    member5 = Member.create!(name: "Chris",
+      money_spent: 250,
+      co_resident: true,
+      gym_id: gym2.id)
+
+    visit "/gyms/#{gym1.id}"
+    # save_and_open_page
+
+    expect(page).to have_content("Gym Name: #{gym1.name}")
+    expect(page).to have_content("Number of Members: #{gym1.number_of_members}")
+    expect(page).to have_content("Member Cost Per Month: $#{gym1.member_cost}")
+    expect(page).to have_content("Day Rate for Guests: $#{gym1.guest_cost}")
+    expect(page).to have_content("In Colorado: #{gym1.in_colorado}")
+
+    visit "/gyms/#{gym2.id}"
+    # save_and_open_page
+
+    expect(page).to have_content("Gym Name: #{gym2.name}")
+    expect(page).to have_content("Number of Members: #{gym2.number_of_members}")
     expect(page).to have_content("Member Cost Per Month: $#{gym2.member_cost}")
     expect(page).to have_content("Day Rate for Guests: $#{gym2.guest_cost}")
     expect(page).to have_content("In Colorado: #{gym2.in_colorado}")

--- a/spec/features/gyms/show_spec.rb
+++ b/spec/features/gyms/show_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "gyms index page", type: :feature do
   # As a visitor
   # When I visit any page on the site
   # Then I see a link at the top of the page that takes me to the Child Index
-  it "can show a link to the members page" do
+  it "can show a link to the members index page" do
     gym1 = Gym.create!(name: "Movement",
       member_cost: 92,
       guest_cost: 25,
@@ -135,9 +135,65 @@ RSpec.describe "gyms index page", type: :feature do
       gym_id: gym2.id)
 
     visit "/gyms/#{gym1.id}"
+    # save_and_open_page
 
     expect(page).to have_content("Every Member Everywhere")
     expect(page).to have_link("Every Member Everywhere", href: "/members/")
+
+    visit "/gyms/#{gym2.id}"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Member Everywhere")
+    expect(page).to have_link("Every Member Everywhere", href: "/members/")
+  end
+
+  # User Story 9, Parent Index Link
+
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Parent Index
+  it "can show a link to the gyms index page" do
+    gym1 = Gym.create!(name: "Movement",
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
+    member1 = Member.create!(name: "Garrett",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+    member2 = Member.create!(name: "Audrey",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+
+    gym2 = Gym.create!(name: "The Spot",
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
+    member3 = Member.create!(name: "Brad",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+    member4 = Member.create!(name: "Sarah",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+    member5 = Member.create!(name: "Chris",
+      money_spent: 250,
+      co_resident: true,
+      gym_id: gym2.id)
+
+    visit "/gyms/#{gym1.id}"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Gym Everywhere")
+    expect(page).to have_link("Every Gym Everywhere", href: "/gyms/")
+
+    visit "/gyms/#{gym2.id}"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Gym Everywhere")
+    expect(page).to have_link("Every Gym Everywhere", href: "/gyms/")
   end
 end
 

--- a/spec/features/gyms/show_spec.rb
+++ b/spec/features/gyms/show_spec.rb
@@ -195,5 +195,54 @@ RSpec.describe "gyms index page", type: :feature do
     expect(page).to have_content("Every Gym Everywhere")
     expect(page).to have_link("Every Gym Everywhere", href: "/gyms/")
   end
+
+  # User Story 10, Parent Child Index Link
+
+  # As a visitor
+  # When I visit a parent show page ('/parents/:id')
+  # Then I see a link to take me to that parent's `child_table_name` page ('/parents/:id/child_table_name')
+  it "can show a link to the gyms index page" do
+    gym1 = Gym.create!(name: "Movement",
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
+    member1 = Member.create!(name: "Garrett",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+    member2 = Member.create!(name: "Audrey",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+
+    gym2 = Gym.create!(name: "The Spot",
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
+    member3 = Member.create!(name: "Brad",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+    member4 = Member.create!(name: "Sarah",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+    member5 = Member.create!(name: "Chris",
+      money_spent: 250,
+      co_resident: true,
+      gym_id: gym2.id)
+
+    visit "/gyms/#{gym1.id}"
+    # save_and_open_page
+
+    expect(page).to have_content("Gym Members")
+    expect(page).to have_link("Gym Members", href: "/gyms/#{gym1.id}/members")
+
+    visit "/gyms/#{gym2.id}"
+    # save_and_open_page
+
+    expect(page).to have_content("Gym Members")
+    expect(page).to have_link("Gym Members", href: "/gyms/#{gym2.id}/members")
+  end
 end
 

--- a/spec/features/members/index_spec.rb
+++ b/spec/features/members/index_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "member index page", type: :feature do
+
+  
   # User Story 3, member Index
 
   # As a visitor
@@ -53,20 +55,76 @@ RSpec.describe "member index page", type: :feature do
   # As a visitor
   # When I visit any page on the site
   # Then I see a link at the top of the page that takes me to the Child Index
-  it "can show a link to the members page" do
+  it "can show a link to the members index page" do
     gym1 = Gym.create!(name: "Movement",
-                        member_cost:  92,
-                        guest_cost:   25,
-                        in_colorado:  true,
-                        created_at: Date.today - 1)
-    gym2 = Gym.create!(name: "Touchstone",
-                        member_cost:  100,
-                        guest_cost:   30,
-                        in_colorado:  false)
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
+    member1 = Member.create!(name: "Garrett",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+    member2 = Member.create!(name: "Audrey",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+
+    gym2 = Gym.create!(name: "The Spot",
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
+    member3 = Member.create!(name: "Brad",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+    member4 = Member.create!(name: "Sarah",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+
     visit "/members"
     # save_and_open_page
 
     expect(page).to have_content("Every Member Everywhere")
     expect(page).to have_link("Every Member Everywhere", href: "/members/")
+  end
+
+  # User Story 9, Parent Index Link
+
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Parent Index
+  it "can show a link to the gyms index page" do
+    gym1 = Gym.create!(name: "Movement",
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
+    member1 = Member.create!(name: "Garrett",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+    member2 = Member.create!(name: "Audrey",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+
+    gym2 = Gym.create!(name: "The Spot",
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
+    member3 = Member.create!(name: "Brad",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+    member4 = Member.create!(name: "Sarah",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+
+    visit "/members"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Gym Everywhere")
+    expect(page).to have_link("Every Gym Everywhere", href: "/gyms/")
   end
 end

--- a/spec/features/members/index_spec.rb
+++ b/spec/features/members/index_spec.rb
@@ -47,4 +47,26 @@ RSpec.describe "member index page", type: :feature do
     expect(page).to have_content("Resident of CO?: #{member3.co_resident}")
     expect(page).to have_content("Member of: #{gym2.id}")
   end
+
+  # User Story 8, Child Index Link
+
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Child Index
+  it "can show a link to the members page" do
+    gym1 = Gym.create!(name: "Movement",
+                        member_cost:  92,
+                        guest_cost:   25,
+                        in_colorado:  true,
+                        created_at: Date.today - 1)
+    gym2 = Gym.create!(name: "Touchstone",
+                        member_cost:  100,
+                        guest_cost:   30,
+                        in_colorado:  false)
+    visit "/members"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Member Everywhere")
+    expect(page).to have_link("Every Member Everywhere", href: "/members/")
+  end
 end

--- a/spec/features/members/index_spec.rb
+++ b/spec/features/members/index_spec.rb
@@ -8,31 +8,31 @@ RSpec.describe "member index page", type: :feature do
   # Then I see each member in the system including the member's attributes
   # (data from each column that is on the member table)
   it "can show all of the members" do
-    gym1 = Gym.create!(name:         "Movement",
-                      member_cost:  92,
-                      guest_cost:   25,
-                      in_colorado:  true)
-    member1 = Member.create!(name:         "Garrett",
-                            money_spent: 300,
-                            co_resident: true,
-                            gym_id: gym1.id)
-    member2 = Member.create!(name:         "Audrey",
-                            money_spent: 300,
-                            co_resident: true,
-                            gym_id: gym1.id)
+    gym1 = Gym.create!(name: "Movement",
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
+    member1 = Member.create!(name: "Garrett",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
+    member2 = Member.create!(name: "Audrey",
+      money_spent: 300,
+      co_resident: true,
+      gym_id: gym1.id)
 
     gym2 = Gym.create!(name: "The Spot",
-                      member_cost:  75,
-                      guest_cost:   20,
-                      in_colorado:  true)
-    member3 = Member.create!(name:         "Brad",
-                            money_spent: 250,
-                            co_resident: false,
-                            gym_id: gym2.id)
-    member4 = Member.create!(name:         "Sarah",
-                            money_spent: 250,
-                            co_resident: false,
-                            gym_id: gym2.id)
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
+    member3 = Member.create!(name: "Brad",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
+    member4 = Member.create!(name: "Sarah",
+      money_spent: 250,
+      co_resident: false,
+      gym_id: gym2.id)
 
     visit "/members"
     # save_and_open_page

--- a/spec/features/members/show_spec.rb
+++ b/spec/features/members/show_spec.rb
@@ -61,11 +61,35 @@ RSpec.describe "member show page", type: :feature do
   # When I visit any page on the site
   # Then I see a link at the top of the page that takes me to the Child Index
   it "can show a link to the members page" do
-    visit "/members/#{@member3.id}"
-
+    visit "/members/#{@member1.id}"
     # save_and_open_page
 
     expect(page).to have_content("Every Member Everywhere")
     expect(page).to have_link("Every Member Everywhere", href: "/members/")
+
+    visit "/members/#{@member3.id}"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Member Everywhere")
+    expect(page).to have_link("Every Member Everywhere", href: "/members/")
+  end
+
+  # User Story 9, Parent Index Link
+
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Parent Index
+  it "can show a link to the members page" do
+    visit "/members/#{@member1.id}"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Gym Everywhere")
+    expect(page).to have_link("Every Gym Everywhere", href: "/gyms/")
+
+    visit "/members/#{@member3.id}"
+    # save_and_open_page
+
+    expect(page).to have_content("Every Gym Everywhere")
+    expect(page).to have_link("Every Gym Everywhere", href: "/gyms/")
   end
 end

--- a/spec/features/members/show_spec.rb
+++ b/spec/features/members/show_spec.rb
@@ -54,4 +54,18 @@ RSpec.describe "member show page", type: :feature do
     expect(page).to have_content("Resident of CO?: #{@member3.co_resident}")
     expect(page).to have_content("Member of: #{@gym2.id}")
   end
+
+  # User Story 8, Child Index Link
+
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Child Index
+  it "can show a link to the members page" do
+    visit "/members/#{@member3.id}"
+
+    # save_and_open_page
+
+    expect(page).to have_content("Every Member Everywhere")
+    expect(page).to have_link("Every Member Everywhere", href: "/members/")
+  end
 end

--- a/spec/features/members/show_spec.rb
+++ b/spec/features/members/show_spec.rb
@@ -9,30 +9,30 @@ RSpec.describe "member show page", type: :feature do
   # (data from each column that is on the child table)
   before :each do
     @gym1 = Gym.create!(name: "Movement",
-                        member_cost:  92,
-                        guest_cost:   25,
-                        in_colorado:  true)
+      member_cost: 92,
+      guest_cost: 25,
+      in_colorado: true)
     @member1 = Member.create!(name: "Garrett",
-                              money_spent: 300,
-                              co_resident: true,
-                              gym_id: @gym1.id)
+      money_spent: 300,
+      co_resident: true,
+      gym_id: @gym1.id)
     @member2 = Member.create!(name: "Audrey",
-                              money_spent: 300,
-                              co_resident: true,
-                              gym_id: @gym1.id)
+      money_spent: 300,
+      co_resident: true,
+      gym_id: @gym1.id)
 
     @gym2 = Gym.create!(name: "The Spot",
-                        member_cost:  75,
-                        guest_cost:   20,
-                        in_colorado:  true)
+      member_cost: 75,
+      guest_cost: 20,
+      in_colorado: true)
     @member3 = Member.create!(name: "Brad",
-                              money_spent: 250,
-                              co_resident: false,
-                              gym_id: @gym2.id)
+      money_spent: 250,
+      co_resident: false,
+      gym_id: @gym2.id)
     @member4 = Member.create!(name: "Sarah",
-                              money_spent: 250,
-                              co_resident: false,
-                              gym_id: @gym2.id)
+      money_spent: 250,
+      co_resident: false,
+      gym_id: @gym2.id)
   end
 
   it "can show one of the members" do

--- a/spec/models/gym_spec.rb
+++ b/spec/models/gym_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Gym, type: :model do
     it { should have_many :members }
   end
 
-  describe "#order_by_created_at" do
+  describe "#ordered_members_at" do
     it "will sort items in most recently created order" do
       gym1 = Gym.create!(name: "Touchstone",
         member_cost: 100,
@@ -16,10 +16,10 @@ RSpec.describe Gym, type: :model do
         guest_cost: 25,
         in_colorado: true)
 
-      # actual = Gym.order_by_created
+      # actual = Gym.ordered_members
       # expected/result = [gym2,gym1]
 
-      expect(Gym.order_by_created).to eq([gym2,gym1])
+      expect(Gym.ordered_members).to eq([gym2,gym1])
     end
   end
 

--- a/spec/models/gym_spec.rb
+++ b/spec/models/gym_spec.rb
@@ -4,4 +4,60 @@ RSpec.describe Gym, type: :model do
   describe "relationships" do
     it { should have_many :members }
   end
+
+  describe "#order_by_created_at" do
+    it "will sort items in most recently created order" do
+      gym1 = Gym.create!(name: "Touchstone",
+        member_cost: 100,
+        guest_cost: 30,
+        in_colorado: false)
+      gym2 = Gym.create!(name: "Movement",
+        member_cost: 92,
+        guest_cost: 25,
+        in_colorado: true)
+
+      # actual = Gym.order_by_created
+      # expected/result = [gym2,gym1]
+
+      expect(Gym.order_by_created).to eq([gym2,gym1])
+    end
+  end
+
+  describe "#number_of_members" do
+    it "will calculate the number of members at a gym" do
+      gym1 = Gym.create!(name: "Movement",
+        member_cost: 92,
+        guest_cost: 25,
+        in_colorado: true)
+      member1 = Member.create!(name: "Garrett",
+        money_spent: 300,
+        co_resident: true,
+        gym_id: gym1.id)
+      member2 = Member.create!(name: "Audrey",
+        money_spent: 300,
+        co_resident: true,
+        gym_id: gym1.id)
+
+      gym2 = Gym.create!(name: "The Spot",
+        member_cost: 75,
+        guest_cost: 20,
+        in_colorado: true)
+      member3 = Member.create!(name: "Brad",
+        money_spent: 250,
+        co_resident: false,
+        gym_id: gym2.id)
+      member4 = Member.create!(name: "Sarah",
+        money_spent: 250,
+        co_resident: false,
+        gym_id: gym2.id)
+      member5 = Member.create!(name: "Chris",
+        money_spent: 250,
+        co_resident: true,
+        gym_id: gym2.id)
+
+      expect(gym1.number_of_members).to eq(2)
+      expect(gym2.number_of_members).to eq(3)
+    end
+  end
+
 end


### PR DESCRIPTION
users stories 6-10 completed with 100% coverage
- Simplecov @ 100%

# User Story 6, Parent Index sorted by Most Recently Created 
[✅] done

As a visitor
When I visit the parent index,
I see that records are ordered by most recently created first
And next to each of the records I see when it was created

# User Story 7, Parent Child Count
[✅] done

As a visitor
When I visit a parent's show page
I see a count of the number of children associated with this parent

# User Story 8, Child Index Link
[✅] done

As a visitor
When I visit any page on the site
Then I see a link at the top of the page that takes me to the Child Index

# User Story 9, Parent Index Link
[✅] done

As a visitor
When I visit any page on the site
Then I see a link at the top of the page that takes me to the Parent Index

# User Story 10, Parent Child Index Link
[✅] done

As a visitor
When I visit a parent show page ('/parents/:id')
Then I see a link to take me to that parent's `child_table_name` page ('/parents/:id/child_table_name')